### PR TITLE
Compile on 1.38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Before it can run, `cargo` will have to download and compile all necessary
 dependencies, as well as compile this project's source, so it may take a few
 moments.
 
+If you don't have Rust, you can get it using [Rustup][rustup]. I will try to
+keep the project compiling on stable Rust, but I reserve the right to require
+nightly if there's a really nice feature I want. :)
+
+[rustup]: https://rustup.rs/
+
 
 ## Controls
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![feature(const_fn)]
 
 #[macro_use]
 extern crate derive_more;


### PR DESCRIPTION
We had a feature flag that required nightly Rust, but it turns out we didn't actually need it. The code compiles fine on 1.38.0. This merge request removes that feature flag.

Also, I've added a link to Rustup in the README so people can download the Rust toolchain if they need it.

Fixes #5.